### PR TITLE
fix(pom.xml) fix testNG vulnarability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project 
+adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - yyyy-mm-dd
 
 ### Added
 
 - The new statement for the checking logical assertions.
+
+## [0.13.1] - 2022-06-17
+
+### Fixed
+
+- TestNG is vulnerable to Path Traversal vulnerability - update dependency for testng from 
+  version 7.1.0 to 7.6.1.
+
+## [0.13.0] - 2022-06-17
+
+### Fixed
+
+- Fatal: super() could be on a first place #18. An error occurs when using an annotation
+  from a statement package in a constructor. The error is related to the fact that the super()
+  keyword must be the first one in the constructor.
+
+### Added
+
+- Init new AbstractTrickyProcessor for the providing the simplest way for tricky processing
+  (using task listeners instead #process method).
 
 ## [0.12.1] - 2022-02-14
 
@@ -28,13 +49,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - Fatal: super() could be on a first place #18. An error occurs when using an annotation
-from a statement package in a constructor. The error is related to the fact that the super() keyword
-must be the first one in the constructor.
+  from a statement package in a constructor. The error is related to the fact that the super() 
+  keyword must be the first one in the constructor.
 
 ## Added
 
-- Init new AbstractTrickyProcessor for the providing simplest way for tricky processing
-(using task listeners instead #process method)
+- Init new AbstractTrickyProcessor for the providing the simplest way for tricky processing
+  (using task listeners instead #process method)
 
 ## [0.10.0] - 2022-01-23
 
@@ -60,13 +81,13 @@ must be the first one in the constructor.
 ### Changed
 
 - Better processing local variables annotated by `Statement` annotations. Now there is no need
-for additional annotation of a method or class with an annotation `IncludeVarsLocal`
-so that the `Statement` annotation processor could to process local variables.
+  for additional annotation of a method or class with an annotation `IncludeVarsLocal`
+  so that the `Statement` annotation processor could to process local variables.
 
 ### Deprecated
 
 - The `IncludeVarsLocal` annotation is deprecated now. Because new annotation processing
-could to scan local variables during `ENTER` compilation phase.
+  could to scan local variables during `ENTER` compilation phase.
 
 ## [0.8.0] - 2022-01-07
 
@@ -84,7 +105,8 @@ could to scan local variables during `ENTER` compilation phase.
 
 ### Added
 
-- The new module `cranberry-data` with annotation `Final` - for the finalizing local variables and params modifiers.
+- The new module `cranberry-data` with annotation `Final` - for the finalizing local variables  
+  and params modifiers.
 
 ## [0.5.4] - 2022-01-03
 
@@ -114,7 +136,8 @@ could to scan local variables during `ENTER` compilation phase.
 
 ### Fixed
 
-- Wrong exception for `NotBlankStatement.check()` method - was `NotEmptyStatementException`, but expected `NotBlankStatementException`.
+- Wrong exception for `NotBlankStatement.check()` method - was `NotEmptyStatementException`,
+  but expected `NotBlankStatementException`.
 
 ## [0.5.0] - 2021-12-25
 
@@ -132,25 +155,33 @@ could to scan local variables during `ENTER` compilation phase.
 
 ### Fixed
 
-- The the validation type of annotated by `@NotEmpty` target - it was only true for not applicable types.
+- The validation type of annotated by `@NotEmpty` target - it was only true for not applicable types.
 
 ## [0.3.0] - 2020-08-27
 
 ### Added
 
-- The the `@True` annotation and `true` statement checker.
+- The `@True` annotation and `true` statement checker.
 
 ## [0.2.0] - 2020-08-10
 
 ### Added
 
-- The module [cranberry logging](cranberry-logging/README.md) which provides an api for the loggint method params. This module includes an annotations for the injecting methods of this api into code during compilation.
+- The module [cranberry logging](cranberry-logging/README.md) which provides an api for the logging 
+  method params. This module includes an annotations for the injecting methods of this api into code 
+  during compilation.
 
 ## [0.1.0] - 2020-04-17
 
 ### Added
 - Initial public release of the cranberry with the following modules:
-    - The module [cranberry engine](cranberry-engine/README.md) which provides a general realisation of simple tools and wrappers which are used in another cranberry modules for the automatically code generating during compilation.
-    - The module [cranberry statement](cranberry-statement/README.md) which provides an api for the statements validation (such as not null and e.t.c.). This module includes an annotations for the injecting methods of this api into code during compilation.
-    - The module [cranberry muffin](cranberry-statement/README.md) which is designed to combine the possibilities of thematically grouped modules into one common library.
-    - The module [cranberry tests](cranberry-tests/README.md) which will contain the unit tests for the remaining modules of the cranberry project.
+    - The module [cranberry engine](cranberry-engine/README.md) which provides a general realisation
+      of simple tools and wrappers which are used in another cranberry modules for the automatically 
+      code generating during compilation.
+    - The module [cranberry statement](cranberry-statement/README.md) which provides an api for the 
+      statements validation (such as not null and e.t.c.). This module includes an annotations for 
+      the injecting methods of this api into code during compilation.
+    - The module [cranberry muffin](cranberry-statement/README.md) which is designed to combine the 
+      possibilities of thematically grouped modules into one common library.
+    - The module [cranberry tests](cranberry-tests/README.md) which will contain the unit tests for 
+      the remaining modules of the cranberry project.

--- a/cranberry-statement/src/main/java/io/github/ololx/cranberry/statement/processing/CranberryStatementTaskListener.java
+++ b/cranberry-statement/src/main/java/io/github/ololx/cranberry/statement/processing/CranberryStatementTaskListener.java
@@ -43,7 +43,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static com.sun.source.util.TaskEvent.Kind.*;
+import static com.sun.source.util.TaskEvent.Kind.ANNOTATION_PROCESSING_ROUND;
+import static com.sun.source.util.TaskEvent.Kind.ENTER;
 
 /**
  * project cranberry

--- a/cranberry-tests/pom.xml
+++ b/cranberry-tests/pom.xml
@@ -44,7 +44,7 @@
     <!--[properties-->
     <properties>
         <!--[dependencies versions-->
-        <dependency.testng.version>7.1.0</dependency.testng.version>
+        <dependency.testng.version>7.6.1</dependency.testng.version>
         <dependency.equalsverifier.version>3.0.3</dependency.equalsverifier.version>
         <!--dependencies versions]-->
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <!--[properties-->
     <properties>
         <!--[project versions-->
-        <revision>0.13.0</revision>
+        <revision>0.13.1</revision>
         <changelist></changelist>
         <sha1/>
         <!--project versions]-->


### PR DESCRIPTION
Fix #23 - update dependency for TestNG from version 7.1.0 to 7.6.1. 